### PR TITLE
Changed certificate extension

### DIFF
--- a/mitm/CA.go
+++ b/mitm/CA.go
@@ -19,7 +19,7 @@ var (
 
 	dir      = path.Join(getUserHomeDir(), ".wapty")
 	keyFile  = path.Join(dir, "ca-key.pem")
-	certFile = path.Join(dir, "ca-cert.pem")
+	certFile = path.Join(dir, "ca-cert.crt")
 )
 
 func getUserHomeDir() string {


### PR DESCRIPTION
A certificate have by default a `.crt` extension that permits to be quickly installed on windows.
In my tests, the edit of the name didn't compromise the application.