### PR TITLE
Command

### DIFF
--- a/common/command.go
+++ b/common/command.go
@@ -4,21 +4,63 @@ import (
 	"flag"
 	"fmt"
 	"os"
+	"strings"
 )
+
+// WaptyCommands is the list of all wapty commands available.
+// Each command `cmd` is invoked via `wapty cmd`
+var WaptyCommands []*Command
 
 // Command is used by any package exposing a runnable command to gather information
 // about command name, usage and flagset.
 type Command struct {
-	Name      string
-	Run       func()
+	// Name is the name of the command. It's what comes after `wapty`.
+	Name string
+
+	// Run is the command entrypoint.
+	Run func()
+
+	// UsageLine is the header of what's printed by flag.PrintDefaults.
 	UsageLine string
-	Short     string
-	Long      string
-	Flag      flag.FlagSet
+
+	// Short is a one-line description of what the command does.
+	Short string
+
+	// Long is the detailed description of what the command does.
+	Long string
+
+	// Flag is the set of flags accepted by the command. This should be initialized in
+	// the command's module's `init` function. The parsing of these flags is issued
+	// by the main wapty entrypoint, so each command doesn't have to do it itself.
+	Flag flag.FlagSet
 }
 
 func (c *Command) Usage() {
 	fmt.Fprintf(os.Stderr, "usage: %s\n\n", c.UsageLine)
 	c.Flag.PrintDefaults()
 	os.Exit(2)
+}
+
+// FindCommand takes a string and searches for a command whose name has that string as
+// prefix. If more than 1 command name has that string as a prefix (and no command name
+// equals that string), an error is returned. If no suitable command is found, an error
+// is returned.
+func FindCommand(name string) (command *Command, err error) {
+	for _, cmd := range WaptyCommands {
+		if cmd.Name == name {
+			command = cmd
+			return
+		}
+		if strings.HasPrefix(cmd.Name, name) {
+			if command != nil {
+				err = fmt.Errorf("Ambiguous command: '%s'.", name)
+			} else {
+				command = cmd
+			}
+		}
+	}
+	if command == nil {
+		err = fmt.Errorf("Command not found: '%s'.", name)
+	}
+	return
 }

--- a/common/command.go
+++ b/common/command.go
@@ -1,0 +1,24 @@
+package common
+
+import (
+	"flag"
+	"fmt"
+	"os"
+)
+
+// Command is used by any package exposing a runnable command to gather information
+// about command name, usage and flagset.
+type Command struct {
+	Name      string
+	Run       func()
+	UsageLine string
+	Short     string
+	Long      string
+	Flag      flag.FlagSet
+}
+
+func (c *Command) Usage() {
+	fmt.Fprintf(os.Stderr, "usage: %s\n\n", c.UsageLine)
+	c.Flag.PrintDefaults()
+	os.Exit(2)
+}

--- a/decode/init.go
+++ b/decode/init.go
@@ -2,7 +2,7 @@ package decode
 
 import "github.com/empijei/wapty/common"
 
-var CmdDecode = common.Command{
+var CmdDecode = &common.Command{
 	Name:      "decode",
 	Run:       MainStandalone,
 	UsageLine: "decode [flags]",

--- a/decode/init.go
+++ b/decode/init.go
@@ -1,0 +1,25 @@
+package decode
+
+import "github.com/empijei/wapty/common"
+
+var CmdDecode = common.Command{
+	Name:      "decode",
+	Run:       MainStandalone,
+	UsageLine: "decode [flags]",
+	Short:     "decode something.",
+	Long: `decode something in a really clever way:
+
+blah blah blah
+	`,
+}
+
+var flagEncode bool      // -encode
+var flagCodeclist string // -codec
+
+func init() {
+	CmdDecode.Flag.BoolVar(&flagEncode, "encode", false, "Sets the decoder to an encoder instead")
+	CmdDecode.Flag.StringVar(&flagCodeclist, "codec", "smart",
+		`Sets the decoder/encoder codec. Multiple codecs can be specified and comma separated:
+	they will be applied one on the output of the previous as in a pipeline.
+	`)
+}

--- a/decode/main.go
+++ b/decode/main.go
@@ -8,35 +8,19 @@ import (
 	"strings"
 )
 
-var FlagEncode *bool
-var FlagCodeclist *string
-
-// RegisterFlagStandalone initialiases the flags for the decode package
-func RegisterFlagStandalone() {
-	FlagEncode = flag.Bool("encode", false, "Sets the decoder to an encoder instead")
-	FlagCodeclist = flag.String("codec", "smart", "Sets the decoder/encoder codec. Multiple codecs can be specified and comma separated, they will be applied one on the output of the previous as in a pipeline.")
-}
-
 // MainStandalone parses its own flag and it is the funcion to be run when using
 // `wapty decode`. This behaves as a main and expects the "decode" parameter to
 // be removed from os.Args.
 func MainStandalone() {
-	if flag.Parsed() == false {
-		RegisterFlagStandalone()
-		flag.Usage = func() {
-			fmt.Fprintln(os.Stderr, "Usage of decoder:")
-			flag.PrintDefaults()
-		}
-		flag.Parse()
-	}
 
+	// FIXME: argument validation should be separated from encoding/decoding
 	buf := takeInput()
-	sequence := strings.Split(*FlagCodeclist, ",")
+	sequence := strings.Split(flagCodeclist, ",")
 	for i, codec := range sequence {
 		var c CodecC
 		var codecNames []string
 		if codec == "smart" {
-			if *FlagEncode {
+			if flagEncode {
 				fmt.Fprintf(os.Stderr, "Cannot 'smart' encode, please specify a codec")
 				os.Exit(2)
 			}
@@ -54,7 +38,7 @@ func MainStandalone() {
 			}
 		}
 		fmt.Fprintf(os.Stderr, "Codec: %s\n", c.Name())
-		if *FlagEncode {
+		if flagEncode {
 			buf = c.Encode()
 		} else {
 			buf = c.Decode()

--- a/help/help.go
+++ b/help/help.go
@@ -1,0 +1,46 @@
+package help
+
+import (
+	"fmt"
+	"os"
+	"strings"
+	"text/template"
+	"unicode"
+	"unicode/utf8"
+
+	"github.com/empijei/wapty/common"
+)
+
+const docTemplate = `{{.Name | capitalize}}: {{.Short}}
+
+Usage:
+	go {{.UsageLine}}
+
+{{.Long | trim}}
+`
+
+var outw = os.Stderr
+
+func Main() {
+	requestedCmd := "help"
+	if len(os.Args) > 1 {
+		requestedCmd = os.Args[1]
+	}
+
+	if command, err := common.FindCommand(requestedCmd); err == nil {
+		tmpl := template.New("help")
+		tmpl.Funcs(template.FuncMap{"trim": strings.TrimSpace, "capitalize": capitalize})
+		template.Must(tmpl.Parse(docTemplate))
+		tmpl.Execute(outw, command)
+	} else {
+		fmt.Fprintf(outw, "help: error processing command: %s\n", err.Error())
+	}
+}
+
+func capitalize(s string) string {
+	if s == "" {
+		return s
+	}
+	r, n := utf8.DecodeRuneInString(s)
+	return string(unicode.ToTitle(r)) + s[n:]
+}

--- a/help/init.go
+++ b/help/init.go
@@ -1,0 +1,11 @@
+package help
+
+import "github.com/empijei/wapty/common"
+
+var CmdHelp = &common.Command{
+	Name:      "help",
+	Run:       Main,
+	UsageLine: "help",
+	Short:     "display help information for wapty commands",
+	Long:      "",
+}

--- a/mocksy/init.go
+++ b/mocksy/init.go
@@ -9,7 +9,7 @@ import (
 
 var outw io.Writer
 
-var CmdMocksy = common.Command{
+var CmdMocksy = &common.Command{
 	Name:      "mocksy",
 	Run:       Main,
 	UsageLine: "mocksy",

--- a/mocksy/init.go
+++ b/mocksy/init.go
@@ -3,9 +3,19 @@ package mocksy
 import (
 	"io"
 	"os"
+
+	"github.com/empijei/wapty/common"
 )
 
 var outw io.Writer
+
+var CmdMocksy = common.Command{
+	Name:      "mocksy",
+	Run:       Main,
+	UsageLine: "mocksy",
+	Short:     "mock responses from a server",
+	Long:      "",
+}
 
 func init() {
 	responseHistory = make([]Item, 0)


### PR DESCRIPTION
Addresses #4. Many ideas were taken from https://github.com/golang/go/blob/master/src/cmd/go.

### What I changed
Basically I slightly changed the way that wapty subcommands are organized. Now every package that exports a standalone main must declare a `*common.Command` variable which contains the information needed to run it, the flags it accepts (if any) and the usage description.

More specifically, these packages should have a `init.go` file containing:  
1. the Command exported variable, like:  
```go
package decode
var CmdDecode = &common.Command{
    // ...
}
```  
2. optionally, the `init()` function of that package. I suggest this be in the same file as the exported Command variable as it can be used to initialize the command flagset if needed (see `decode/init.go` for an example).

The wapty main entrypoint was changed to adapt to these changes, but the logic remains the same.
Note that the `proxy` and the `version` commands were also changed to adapt to this interface.

### What I added
I added a `common` package, containing the definition of a `Command` plus a convenient `FindCommand` function which contains the logic that was previously in `invokeMain`. I factored this logic out since the new `help` package needed the same exact thing. The new function returns an `error` instead of setting a `success` bool variable.

I also added a `help` package which exports a `help` command that just prints the detailed information about a subcommand (which is different from the `-h` of that command).

### How the flags work now
As I mentioned, every Command contains its flagset, whose parsing is now completely done by the `invokeMain` function. This is convenient as it eliminates repeated flag parsing logic in every command's entrypoint. 
So, if your command needs some custom flags, do this:  
1. in the file containing your command's entrypoint, declare your flag variables (e.g. `flagMyBool`);  
2. create an `init.go` file for your package and define your Command atop of it;  
3. in the `init` function call `CmdMyCommand.Flag.BoolVar(&flagMyBool, "false", "blah", "blah")`;  
4. when your main will be called, the flags will be ready for use, so just use them normally.

---
Ideas/critiques/suggestions are welcome :-)